### PR TITLE
add a test to make sure error is set to false when field is valid

### DIFF
--- a/__tests__/form-schema.js
+++ b/__tests__/form-schema.js
@@ -345,4 +345,20 @@ describe('validation', () => {
       expect(testAdapter.text.mock.instances.length).toBe(1);
     });
   });
+
+  it(`sets error key to false fields that are valid`, () => {
+    testAdapter.text = jest.fn().mockReturnValue(false);
+    formSchema.registerValidator(testAdapter);
+    formSchema.addField({type: 'text', error: ['error message']});
+
+    return formSchema.validate().then(isValid => {
+      expect(isValid).toBe(true);
+      expect(formSchema.getSchemaObject()).toEqual({
+        name: '',
+        fields: [
+          { type: 'text', error: false }
+        ],
+      });
+    });
+  });
 });


### PR DESCRIPTION
An alternative to this is is to unset the error key, but setting error to false seems appropriate to me